### PR TITLE
Modifies default wsrep_slave_threads to 30

### DIFF
--- a/manifests/profile/pacemaker/database/mysql.pp
+++ b/manifests/profile/pacemaker/database/mysql.pp
@@ -74,7 +74,7 @@ class tripleo::profile::pacemaker::database::mysql (
       'wsrep_provider'                => '/usr/lib64/galera/libgalera_smm.so',
       'wsrep_cluster_name'            => 'galera_cluster',
       'wsrep_cluster_address'         => "gcomm://${galera_nodes}",
-      'wsrep_slave_threads'           => '1',
+      'wsrep_slave_threads'           => '30',
       'wsrep_certify_nonPK'           => '1',
       'wsrep_max_ws_rows'             => '131072',
       'wsrep_max_ws_size'             => '1073741824',


### PR DESCRIPTION
This change attempts to alleviate cpu contention by increasing the
number of threads.  CPU usage is high during deployment, so this may
help.

Signed-off-by: Tim Rozet tdrozet@gmail.com
