### PR TITLE
Enables OpenDaylight Clustering in HA deployments

### DIFF
--- a/manifests/profile/base/neutron/opendaylight.pp
+++ b/manifests/profile/base/neutron/opendaylight.pp
@@ -22,19 +22,34 @@
 #   (Optional) The current step of the deployment
 #   Defaults to hiera('step')
 #
-# [*primary_node*]
-#   (Optional) The hostname of the first node of this role type
-#   Defaults to hiera('bootstrap_nodeid', undef)
+# [*odl_api_ips*]
+#   (Optional) List of OpenStack Controller IPs for ODL API
+#   Defaults to hiera('opendaylight_api_node_ips')
+#
+# [*node_name*]
+#   (Optional) The short hostname of node
+#   Defaults to hiera('bootstack_nodeid')
 #
 class tripleo::profile::base::neutron::opendaylight (
   $step         = hiera('step'),
-  $primary_node = hiera('bootstrap_nodeid', undef),
+  $odl_api_ips  = hiera('opendaylight_api_node_ips'),
+  $node_name    = hiera('bootstack_nodeid')
 ) {
 
   if $step >= 1 {
-    # Configure ODL only on first node of the role where this service is
-    # applied
-    if $primary_node == downcase($::hostname) {
+    if empty($odl_api_ips) {
+      fail('No IPs assigned to OpenDaylight Api Service')
+    } elsif size($odl_api_ips) == 2 {
+      fail('2 node OpenDaylight deployments are unsupported.  Use 1 or greater than 2')
+    } elsif size($odl_api_ips) > 2 {
+      $node_string = split($node_name, '-')
+      $ha_node_index = $node_string[-1] + 1
+      class { '::opendaylight':
+        enable_ha     => true,
+        ha_node_ips   => $odl_api_ips,
+        ha_node_index => $ha_node_index,
+      }
+    } else {
       include ::opendaylight
     }
   }

--- a/manifests/profile/base/neutron/plugins/ml2/opendaylight.pp
+++ b/manifests/profile/base/neutron/plugins/ml2/opendaylight.pp
@@ -30,6 +30,10 @@
 #   (Optional) Password to configure for OpenDaylight
 #   Defaults to 'admin'
 #
+# [*odl_url_ip*]
+#   (Optional) Virtual IP address for ODL Api Service
+#   Defaults to hiera('opendaylight_api_vip')
+#
 # [*conn_proto*]
 #   (Optional) Protocol to use to for ODL REST access
 #   Defaults to hiera('opendaylight::nb_connection_protocol')
@@ -43,14 +47,13 @@ class tripleo::profile::base::neutron::plugins::ml2::opendaylight (
   $odl_port     = hiera('opendaylight::odl_rest_port'),
   $odl_username = hiera('opendaylight::username'),
   $odl_password = hiera('opendaylight::password'),
+  $odl_url_ip   = hiera('opendaylight_api_vip'),
   $conn_proto   = hiera('opendaylight::nb_connection_protocol'),
   $step         = hiera('step'),
 ) {
 
   if $step >= 4 {
-    $odl_url_ip = hiera('opendaylight_api_vip')
-
-    if ! $odl_url_ip { fail('OpenDaylight Controller IP/VIP is Empty') }
+    if ! $odl_url_ip { fail('OpenDaylight API VIP is Empty') }
 
     class { '::neutron::plugins::ml2::opendaylight':
       odl_username => $odl_username,


### PR DESCRIPTION
Previously ODL was restricted to only running on the first node in an
tripleO HA deployment.  This patches enables clustering for ODL and
allows multiple ODL instances (minimum 3 for HA).

Partially-implements: blueprint opendaylight-ha

Change-Id: Ic9a955a1c2afc040b2f9c6fb86573c04a60f9f31
Signed-off-by: Tim Rozet <trozet@redhat.com>
(cherry picked from commit f60922da5b6fbc2a4f4f2314d1978e901d196980)