### PR TITLE
mariadb: Move generation of systemd drop-in to puppet-tripleo

### DIFF
--- a/manifests/profile/base/database/mysql.pp
+++ b/manifests/profile/base/database/mysql.pp
@@ -107,7 +107,7 @@ class tripleo::profile::base::database::mysql (
       # Raise the mysql file limit
       ::systemd::service_limits { 'mariadb.service':
         limits => {
-          LimitNOFILE => 16384
+          'LimitNOFILE' => 16384
         }
       }
     }

--- a/manifests/profile/base/database/mysql.pp
+++ b/manifests/profile/base/database/mysql.pp
@@ -26,6 +26,11 @@
 #   (Optional) The hostname of the node responsible for bootstrapping tasks
 #   Defaults to hiera('bootstrap_nodeid')
 #
+# [*generate_dropin_file_limit*]
+#   (Optional) Generate a systemd drop-in file to raise the file descriptor
+#   limit for the mysql service.
+#   Defaults to false
+#
 # [*manage_resources*]
 #   (Optional) Whether or not manage root user, root my.cnf, and service.
 #   Defaults to true
@@ -51,6 +56,7 @@ class tripleo::profile::base::database::mysql (
   $mysql_server_options    = {},
   $remove_default_accounts = true,
   $step                    = hiera('step'),
+  $generate_dropin_file_limit    = false,
 ) {
 
   if $::hostname == downcase($bootstrap_node) {
@@ -95,6 +101,15 @@ class tripleo::profile::base::database::mysql (
       service_manage          => $manage_resources,
       service_enabled         => $manage_resources,
       remove_default_accounts => $remove_default_accounts,
+    }
+
+    if $generate_dropin_file_limit {
+      # Raise the mysql file limit
+      ::systemd::service_limits { 'mariadb.service':
+        limits => {
+          LimitNOFILE => 16384
+        }
+      }
     }
   }
 


### PR DESCRIPTION
Systemd starts mariadb as user mysql, so in order to allow a large
number of connections (e.g. max_connections=4096) it is necessary to
raise the file descriptor limit via a system drop-in file.

When installing an undercloud, such drop-in file is currently
generated by instack-undercloud (in file puppet-stack-config.pp). But
non-HA overcloud also need such drop-in to be generated.

In order to avoid duplicating code, the drop-in creation code should
be provided by puppet-tripleo. By default, no drop-in is generated;
it has to be enabled by instack-undercloud or tripleo-heat-template
once they will use it (resp. to create undercloud or non-HA overcloud).

This patch does not aim at generating a dynamic file limit based on
the number of connections, this should land in another dedicated
patch.  Instead, it just reuses the limit currently set for undercloud
and HA-overclouds.

Also, the generation of the drop-in does not force a mysql restart
like it currently does in instack-undercloud, to avoid unexpected
service disruption on a non-HA overcloud after a minor update.

Co-Authored-By: Tim Rozet <trozet@redhat.com>

Depends-On: I7ca7b5f7614971455cae2bf7c4bf8264b642b0dc

Change-Id: Ia0907b2ab6062a93fb9363e39c86535a490fbaf6
Partial-Bug: #1648181
Related-Bug: #1524809