### PR TITLE
Split ovn plugin and northd configuration

### DIFF
--- a/manifests/haproxy.pp
+++ b/manifests/haproxy.pp
@@ -254,6 +254,10 @@
 #  (optional) Enable or not OpenDaylight binding
 #  Defaults to hiera('opendaylight_api_enabled', false)
 #
+# [*ovn_dbs*]
+#  (optional) Enable or not OVN northd binding
+#  Defaults to hiera('ovn_dbs_enabled', false)
+#
 # [*zaqar_ws*]
 #  (optional) Enable or not Zaqar Websockets binding
 #  Defaults to false
@@ -309,6 +313,8 @@
 #    'nova_novnc_port' (Defaults to 6080)
 #    'nova_novnc_ssl_port' (Defaults to 13080)
 #    'opendaylight_api_port' (Defaults to 8081)
+#    'ovn_nbdb_port' (Defaults to 6641)
+#    'ovn_sbdb_port' (Defaults to 6642)
 #    'sahara_api_port' (Defaults to 8386)
 #    'sahara_api_ssl_port' (Defaults to 13386)
 #    'swift_proxy_port' (Defaults to 8080)
@@ -353,6 +359,7 @@ class tripleo::haproxy (
   $sahara                    = hiera('sahara_api_enabled', false),
   $tacker                    = hiera('tacker_enabled', false),
   $trove                     = hiera('trove_api_enabled', false),
+  $ovn_dbs                     = hiera('ovn_dbs_enabled', false),
   $glance_api                = hiera('glance_api_enabled', false),
   $glance_registry           = hiera('glance_registry_enabled', false),
   $nova_osapi                = hiera('nova_api_enabled', false),
@@ -385,7 +392,8 @@ class tripleo::haproxy (
   $ui                        = hiera('enable_ui', false),
   $service_ports             = {},
   $congress_network          = hiera('congress_api_network', undef),
-  $tacker_network            = hiera('tacker_api_network', undef)
+  $tacker_network            = hiera('tacker_api_network', undef),
+  $ovn_dbs_network             = hiera('ovn_dbs_network', undef)
 ) {
   $default_service_ports = {
     aodh_api_port => 8042,
@@ -427,6 +435,8 @@ class tripleo::haproxy (
     nova_novnc_port => 6080,
     nova_novnc_ssl_port => 13080,
     opendaylight_api_port => 8081,
+    ovn_nbdb_port => 6641,
+    ovn_sbdb_port => 6642,
     sahara_api_port => 8386,
     sahara_api_ssl_port => 13386,
     swift_proxy_port => 8080,
@@ -1114,6 +1124,37 @@ class tripleo::haproxy (
       listen_options => {
         'balance' => 'source',
       },
+    }
+  }
+
+
+  if $ovn_dbs {
+    # FIXME: is this config enough to ensure we only hit the first node in
+    # ovn_northd_node_ips ?
+    $ovn_db_listen_options = {
+      'option'         => [ 'tcpka' ],
+      'timeout client' => '90m',
+      'timeout server' => '90m',
+      'stick-table'    => 'type ip size 1000',
+      'stick'          => 'on dst',
+    }
+    ::tripleo::haproxy::endpoint { 'ovn_nbdb':
+      public_virtual_ip => $public_virtual_ip,
+      internal_ip       => hiera('ovn_dbs_vip', $controller_virtual_ip),
+      service_port      => $ports[ovn_nbdb_port],
+      ip_addresses      => hiera('ovn_dbs_node_ips', $controller_hosts_real),
+      server_names      => hiera('ovn_dbs_node_names', $controller_hosts_names_real),
+      listen_options    => $ovn_db_listen_options,
+      mode              => 'tcp'
+    }
+    ::tripleo::haproxy::endpoint { 'ovn_sbdb':
+      public_virtual_ip => $public_virtual_ip,
+      internal_ip       => hiera('ovn_dbs_vip', $controller_virtual_ip),
+      service_port      => $ports[ovn_sbdb_port],
+      ip_addresses      => hiera('ovn_dbs_node_ips', $controller_hosts_real),
+      server_names      => hiera('ovn_dbs_node_names', $controller_hosts_names_real),
+      listen_options    => $ovn_db_listen_options,
+      mode              => 'tcp'
     }
   }
 

--- a/manifests/keepalived.pp
+++ b/manifests/keepalived.pp
@@ -59,6 +59,11 @@
 #  A string.
 #  Defaults to false
 #
+# [*ovndbss_virtual_ip*]
+#  Virtual IP on the OVNDBs service.
+#  A string.
+#  Defaults to false
+#
 class tripleo::keepalived (
   $controller_virtual_ip,
   $control_virtual_interface,
@@ -68,6 +73,7 @@ class tripleo::keepalived (
   $storage_virtual_ip      = false,
   $storage_mgmt_virtual_ip = false,
   $redis_virtual_ip        = false,
+  $ovndbs_virtual_ip        = false,
 ) {
 
   case $::osfamily {
@@ -153,6 +159,17 @@ class tripleo::keepalived (
     keepalived::instance { '56':
       interface    => $redis_virtual_interface,
       virtual_ips  => [join([$redis_virtual_ip, ' dev ', $redis_virtual_interface])],
+      state        => 'MASTER',
+      track_script => ['haproxy'],
+      priority     => 101,
+    }
+  }
+  if $ovndbs_virtual_ip and $ovndbs_virtual_ip != $controller_virtual_ip {
+    $ovndbs_virtual_interface = interface_for_ip($ovndbs_virtual_ip)
+    # KEEPALIVE OVNDBS MANAGEMENT NETWORK
+    keepalived::instance { '57':
+      interface    => $ovndbs_virtual_interface,
+      virtual_ips  => [join([$ovndbs_virtual_ip, ' dev ', $ovndbs_virtual_interface])],
       state        => 'MASTER',
       track_script => ['haproxy'],
       priority     => 101,

--- a/manifests/profile/base/neutron/ovn_northd.pp
+++ b/manifests/profile/base/neutron/ovn_northd.pp
@@ -12,31 +12,29 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 #
-# == Class: tripleo::profile::base::neutron::agents::ovn
+# == Class: tripleo::profile::base::neutron::plugins::ml2::ovn
 #
-# OVN Neutron agent profile for tripleo
+# OVN Neutron northd profile for tripleo
 #
-# [*ovn_db_host*]
-#   (Optional) The IP-Address where OVN DBs are listening.
-#   Defaults to hiera('ovn_dbs_vip')
-#
-# [*ovn_sbdb_port*]
-#   (Optional) Port number on which southbound database is listening
-#   Defaults to hiera('ovn::southbound::port')
+# [*bootstrap_node*]
+#   (Optional) The hostname of the node responsible for bootstrapping tasks
+#   Defaults to hiera('bootstrap_nodeid')
 #
 # [*step*]
 #   (Optional) The current step in deployment. See tripleo-heat-templates
 #   for more details.
 #   Defaults to hiera('step')
 #
-class tripleo::profile::base::neutron::agents::ovn (
-  $ovn_db_host    = hiera('ovn_dbs_vip'),
-  $ovn_sbdb_port  = hiera('ovn::southbound::port'),
-  $step           = hiera('step')
+class tripleo::profile::base::neutron::ovn_northd (
+  $bootstrap_node = hiera('bootstrap_nodeid', undef),
+  $step           = hiera('step'),
 ) {
   if $step >= 4 {
-    class { '::ovn::controller':
-      ovn_remote     => "tcp:${ovn_db_host}:${ovn_sbdb_port}",
+    # Note this only runs on the first node in the cluster when
+    # deployed on a role where multiple nodes exist.
+    if $::hostname == downcase($bootstrap_node) {
+      include ::ovn::northd
     }
   }
 }
+

--- a/manifests/profile/base/neutron/plugins/ml2/ovn.pp
+++ b/manifests/profile/base/neutron/plugins/ml2/ovn.pp
@@ -17,7 +17,16 @@
 # OVN Neutron ML2 profile for tripleo
 #
 # [*ovn_db_host*]
-#   The IP-Address/Hostname where OVN DBs are deployed
+#   The IP-Address where OVN DBs are listening.
+#   Defaults to hiera('ovn_dbs_vip')
+#
+# [*ovn_nb_port*]
+#   (Optional) Port number on which northbound database is listening
+#   Defaults to hiera('ovn::northbound::port')
+#
+# [*ovn_sb_port*]
+#   (Optional) Port number on which southbound database is listening
+#   Defaults to hiera('ovn::southbound::port')
 #
 # [*step*]
 #   (Optional) The current step in deployment. See tripleo-heat-templates
@@ -25,18 +34,12 @@
 #   Defaults to hiera('step')
 #
 class tripleo::profile::base::neutron::plugins::ml2::ovn (
-  $ovn_db_host,
-  $step = hiera('step')
+  $ovn_db_host = hiera('ovn_dbs_vip'),
+  $ovn_nb_port = hiera('ovn::northbound::port'),
+  $ovn_sb_port = hiera('ovn::southbound::port'),
+  $step        = hiera('step')
 ) {
   if $step >= 4 {
-    if $::hostname == $ovn_db_host {
-      # NOTE: we might split northd from plugin later, in the case of
-      # micro-services, where neutron-server & northd are not in the same
-      # containers
-      include ::ovn::northd
-    }
-    $ovn_nb_port = hiera('ovn::northbound::port')
-    $ovn_sb_port = hiera('ovn::southbound::port')
     class { '::neutron::plugins::ml2::ovn':
       ovn_nb_connection => "tcp:${ovn_db_host}:${ovn_nb_port}",
       ovn_sb_connection => "tcp:${ovn_db_host}:${ovn_sb_port}",

--- a/manifests/profile/pacemaker/ovn_northd.pp
+++ b/manifests/profile/pacemaker/ovn_northd.pp
@@ -83,11 +83,11 @@ class tripleo::profile::pacemaker::ovn_northd (
     pacemaker::resource::service { "$ovn_northd_resource_name":
       op_params     => 'start timeout=200s stop timeout=200s',
       tries         => $pcs_tries,
-      #location_rule => {
-      #  resource_discovery => 'exclusive',
-      #  score              => 0,
-      #  expression         => ['ovn-northd-role eq true'],
-      #},
+      location_rule => {
+        resource_discovery => 'exclusive',
+        score              => 0,
+        expression         => ['ovn-northd-role eq true'],
+      },
     }
 
     pacemaker::constraint::base { "${ovndb_vip_resource_name}-then-${ovndb_servers_resource_name}":
@@ -110,21 +110,21 @@ class tripleo::profile::pacemaker::ovn_northd (
                           Pacemaker::Resource::Service["${ovn_northd_resource_name}"]],
     }
 
-    pacemaker::constraint::colocation { "${ovndb_vip_resource_name}-with-${ovndb_servers_resource_name}":
-      source       => "${ovndb_vip_resource_name}",
-      target       => "${ovndb_servers_resource_name}-master",
-      master_slave => true,
-      score        => 'INFINITY',
-      require      =>  [Pacemaker::Resource::Ocf["${ovndb_servers_resource_name}"],
-                        Pacemaker::Resource::Ip["${ovndb_vip_resource_name}"]],
-    }
+    #pacemaker::constraint::colocation { "${ovndb_vip_resource_name}-with-${ovndb_servers_resource_name}-INFINITY":
+    #  source       => "${ovndb_vip_resource_name}",
+    #  target       => "${ovndb_servers_resource_name}-master",
+    #  master_slave => true,
+    #  score        => 'INFINITY',
+    #  require      =>  [Pacemaker::Resource::Ocf["${ovndb_servers_resource_name}"],
+    #                    Pacemaker::Resource::Ip["${ovndb_vip_resource_name}"]],
+    #}
 
-    pacemaker::constraint::colocation { "${ovndb_vip_resource_name}-with-${ovn_northd_resource_name}":
-      source  => "${ovndb_vip_resource_name}",
-      target  => "${ovn_northd_resource_name}",
-      score   => 'INFINITY',
-      require => [Pacemaker::Resource::Service["${ovn_northd_resource_name}"],
-                  Pacemaker::Resource::Ip["${ovndb_vip_resource_name}"]],
-    }
+    #pacemaker::constraint::colocation { "${ovndb_vip_resource_name}-with-${ovn_northd_resource_name}-INFINITY":
+    #  source  => "${ovndb_vip_resource_name}",
+    #  target  => "${ovn_northd_resource_name}",
+    #  score   => 'INFINITY',
+    #  require => [Pacemaker::Resource::Service["${ovn_northd_resource_name}"],
+    #              Pacemaker::Resource::Ip["${ovndb_vip_resource_name}"]],
+    #}
   }
 }

--- a/manifests/profile/pacemaker/ovn_northd.pp
+++ b/manifests/profile/pacemaker/ovn_northd.pp
@@ -1,0 +1,130 @@
+# Copyright 2017 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# == Class: tripleo::profile::pacemaker::neutron::plugins::ml2::ovn
+#
+# Neutron ML2 driver Pacemaker HA profile for tripleo
+#
+# === Parameters
+#
+# [*pacemaker_master*]
+#   (Optional) The hostname of the pacemaker master
+#   Defaults to hiera('ovn_dbs_short_bootstrap_node_name')
+#
+# [*step*]
+#   (Optional) The current step in deployment. See tripleo-heat-templates
+#   for more details.
+#   Defaults to hiera('step')
+#
+# [*pcs_tries*]
+#  (Optional) The number of times pcs commands should be retried.
+#   Defaults to hiera('pcs_tries', 20)
+#
+# [*ovn_dbs_vip*]
+#   (Optional) The OVN database virtual IP to be managed by the pacemaker.
+#   Defaults to hiera('ovn_dbs_vip')
+#
+class tripleo::profile::pacemaker::ovn_northd (
+  $pacemaker_master = hiera('bootstack_nodeid'),
+  $step             = hiera('step'),
+  $pcs_tries        = hiera('pcs_tries', 20),
+  $ovn_dbs_vip      = hiera('ovn_dbs_vip'),
+) {
+
+  if $step >= 2 {
+    pacemaker::property { 'ovn-northd-node-property':
+      property => 'ovn-northd-role',
+      value    => true,
+      tries    => $pcs_tries,
+      node     => $::hostname,
+    }
+  }
+
+  # We want the config file to be created on all the cluster nodes,
+  # so that when a slave becomes master, it can start ovn-northd.
+  if $step == 4 and $::osfamily == 'RedHat' {
+    augeas { 'sysconfig-ovn-northd':
+      context =>  '/files/etc/sysconfig/ovn-northd',
+      changes =>  "set OVN_NORTHD_OPTS '\"--db-nb-addr=${ovn_dbs_vip} --db-sb-addr=${ovn_dbs_vip} \
+--db-nb-create-insecure-remote=yes --db-sb-create-insecure-remote=yes --ovn-manage-ovsdb=no\"'",
+    }
+  }
+
+  if $step >= 5 and downcase($::hostname) == $pacemaker_master {
+    $ovndb_servers_resource_name = 'ovndb_servers'
+    $ovn_northd_resource_name    = 'ovn-northd'
+    $ovndb_servers_ocf_name      = 'ovn:ovndb-servers'
+    $ovndb_vip_resource_name     = "ip-${ovn_dbs_vip}"
+    $northd_db_params_path = '/etc/sysconfig/ovn-northd'
+
+    pacemaker::resource::ip { "${ovndb_vip_resource_name}":
+      ip_address   => "${ovn_dbs_vip}",
+      cidr_netmask => 24,
+    }
+
+    pacemaker::resource::ocf { "${ovndb_servers_resource_name}":
+      ocf_agent_name  => "${ovndb_servers_ocf_name}",
+      master_params   => '',
+      resource_params => "master_ip=${ovn_dbs_vip}",
+      meta_params     => 'notify=true'
+    }
+
+    pacemaker::resource::service { "$ovn_northd_resource_name":
+      op_params     => 'start timeout=200s stop timeout=200s',
+      tries         => $pcs_tries,
+      #location_rule => {
+      #  resource_discovery => 'exclusive',
+      #  score              => 0,
+      #  expression         => ['ovn-northd-role eq true'],
+      #},
+    }
+
+    pacemaker::constraint::base { "${ovndb_vip_resource_name}-then-${ovndb_servers_resource_name}":
+      constraint_type => 'order',
+      first_resource  => "${ovndb_vip_resource_name}",
+      second_resource => "${ovndb_servers_resource_name}-master",
+      first_action    => 'start',
+      second_action   => 'start',
+      require         => [Pacemaker::Resource::Ip["${ovndb_vip_resource_name}"],
+                          Pacemaker::Resource::Ocf["${ovndb_servers_resource_name}"]],
+    }
+
+    pacemaker::constraint::base { "${ovndb_servers_resource_name}-then-${ovn_northd_resource_name}":
+      constraint_type => 'order',
+      first_resource  => "${ovndb_servers_resource_name}-master",
+      second_resource => "${ovn_northd_resource_name}",
+      first_action    => 'start',
+      second_action   => 'start',
+      require         => [Pacemaker::Resource::Ocf["${ovndb_servers_resource_name}"],
+                          Pacemaker::Resource::Service["${ovn_northd_resource_name}"]],
+    }
+
+    pacemaker::constraint::colocation { "${ovndb_vip_resource_name}-with-${ovndb_servers_resource_name}":
+      source       => "${ovndb_vip_resource_name}",
+      target       => "${ovndb_servers_resource_name}-master",
+      master_slave => true,
+      score        => 'INFINITY',
+      require      =>  [Pacemaker::Resource::Ocf["${ovndb_servers_resource_name}"],
+                        Pacemaker::Resource::Ip["${ovndb_vip_resource_name}"]],
+    }
+
+    pacemaker::constraint::colocation { "${ovndb_vip_resource_name}-with-${ovn_northd_resource_name}":
+      source  => "${ovndb_vip_resource_name}",
+      target  => "${ovn_northd_resource_name}",
+      score   => 'INFINITY',
+      require => [Pacemaker::Resource::Service["${ovn_northd_resource_name}"],
+                  Pacemaker::Resource::Ip["${ovndb_vip_resource_name}"]],
+    }
+  }
+}


### PR DESCRIPTION
This allows us to use the composable services interfaces to handle
providing the IP address for northd, and will be more flexible in
the event folks want to deploy northd/ovndb on a different node to
the neutron plugin.

This also adds ovn_northd to the haproxy configuration so we can access
it via the ovn_northd_vip in other service profiles.  Note we need
to ensure the haproxy config only hits the bootstrap node as northd
won't be running on the other nodes.

Change-Id: I9af7bd837c340c3df016fc7ad4238b2941ba7a95
Partial-Bug: #1634171