### PR TITLE
Restarts ODL after honeycomb

### DIFF
--- a/manifests/profile/base/neutron/agents/honeycomb.pp
+++ b/manifests/profile/base/neutron/agents/honeycomb.pp
@@ -30,6 +30,12 @@ class tripleo::profile::base::neutron::agents::honeycomb (
   $step = hiera('step'),
 ) {
   if $step >= 4 {
-    include ::fdio::honeycomb
+    if $hostname =~ /.*controller.*/ {
+      class { '::fdio::honeycomb':
+        notify => Service['opendaylight']
+      }
+    } else {
+      include ::fdio::honeycomb
+    }
   }
 }


### PR DESCRIPTION
We find that with honeycomb, ODL requires a restart when mounting
sometimes to properly enter the nodes into the oper database.

Signed-off-by: Tim Rozet <tdrozet@gmail.com>