### PR TITLE
Fixes OpenDaylight configuration step to only step 1

### DIFF
--- a/manifests/profile/base/neutron/opendaylight.pp
+++ b/manifests/profile/base/neutron/opendaylight.pp
@@ -36,7 +36,7 @@ class tripleo::profile::base::neutron::opendaylight (
   $node_name    = hiera('bootstack_nodeid')
 ) {
 
-  if $step >= 1 {
+  if $step == 1 {
     if empty($odl_api_ips) {
       fail('No IPs assigned to OpenDaylight Api Service')
     } elsif size($odl_api_ips) == 2 {


### PR DESCRIPTION
puppet-opendaylight can trigger refresh of ODL service in some cases
where ODL modifies certain files after coming up, or reconfiguring the
ODL user/pass.  We want to avoid ODL restarting during deployment as it
can cause timing errors with OVS trying to connect and fail deployments.
Therefore we only want ODL to be configured and started once in step 1.

Closes-Bug: 1699155

Change-Id: If1a3c3d1d0d5bed407c431bd6bcc877fa150e89a
Signed-off-by: Tim Rozet <trozet@redhat.com>
(cherry picked from commit ca0af07d9799fb88a9675bf3fc3ee1f269624080)